### PR TITLE
Issue #1: 注文CSV行順固定のPDF結合と判定ロジック分離

### DIFF
--- a/build_misumi_upload_csv.py
+++ b/build_misumi_upload_csv.py
@@ -1,6 +1,7 @@
 import os
 import configparser
 import pandas as pd
+import logging
 
 
 import re
@@ -124,17 +125,11 @@ def is_likely_truncated(code: str, min_len: int) -> bool:
         return True
     return False
 
-def can_autofill_prefix(order_code: str, cands: list[str], min_len: int) -> bool:
-    if is_blank(order_code):
-        return False
-    oc = str(order_code).strip()
-    if not is_likely_truncated(oc, min_len):
-        return False
-    hits = [c for c in cands if c.startswith(oc) and len(c) > len(oc)]
-    return len(hits) == 1
-
 def list_pdfs(input_folder: str):
     return [fn for fn in os.listdir(input_folder) if fn.lower().endswith(".pdf") and os.path.isfile(os.path.join(input_folder, fn))]
+
+def list_dxfs(input_folder: str):
+    return [fn for fn in os.listdir(input_folder) if fn.lower().endswith(".dxf") and os.path.isfile(os.path.join(input_folder, fn))]
 
 def build_pdf_drawing_set(input_folder: str, order_no: str, machine_no: str | None):
     pdfs = list_pdfs(input_folder)
@@ -145,6 +140,43 @@ def build_pdf_drawing_set(input_folder: str, order_no: str, machine_no: str | No
         if info:
             drawings.add(info["drawing_no"])
     return drawings
+
+def build_dxf_drawing_set(input_folder: str, order_no: str, machine_no: str | None):
+    dxfs = list_dxfs(input_folder)
+    drawings = set()
+    for fn in dxfs:
+        base = os.path.splitext(os.path.basename(fn))[0]
+        info = parse_filebase_misumi(base, order_no, machine_no)
+        if info:
+            drawings.add(info["drawing_no"])
+    return drawings
+
+def resolve_order_row(order_code: str, cands: list[str], has_dxf: bool):
+    """
+    AUTO/REVIEW/ERROR を明確に分離して判定する。
+    AUTO は「一意候補のみ」。
+    短縮型式補完（prefix補完）は DXF が存在する場合のみ実施する。
+    """
+    if is_blank(order_code):
+        if len(cands) == 1:
+            return "AUTO", "BLANK_ORDER_CODE_SINGLE_CANDIDATE", cands[0]
+        if len(cands) == 0:
+            return "REVIEW", "BLANK_ORDER_CODE_NO_CANDIDATE", ""
+        return "REVIEW", "BLANK_ORDER_CODE_MULTI_CANDIDATE", ""
+
+    if order_code in cands:
+        return "REVIEW", "ORDER_CODE_MATCHED", ""
+
+    if has_dxf:
+        prefix_hits = [c for c in cands if c.startswith(order_code) and len(c) > len(order_code)]
+        if len(prefix_hits) == 1:
+            return "AUTO", "PREFIX_COMPLETION_SINGLE_CANDIDATE", prefix_hits[0]
+        if len(prefix_hits) >= 2:
+            return "REVIEW", "PREFIX_COMPLETION_MULTI_CANDIDATE", ""
+
+    if len(cands) == 0:
+        return "REVIEW", "ORDER_CODE_MISMATCH_NO_CANDIDATE", ""
+    return "REVIEW", "ORDER_CODE_MISMATCH_MULTI_OR_DIFFERENT", ""
 
 def load_candidates_xlsx(output_folder: str, order_no: str, machine_no: str | None):
     combined_path = os.path.join(output_folder, "combine_misumi_types.xlsx")
@@ -182,6 +214,7 @@ def load_candidates_xlsx(output_folder: str, order_no: str, machine_no: str | No
     return drawing_to_candidates
 
 def main():
+    logging.basicConfig(level=logging.INFO)
     config, _ = load_config()
 
     output_folder = os.path.normpath(config["paths"]["output_folder"])
@@ -198,10 +231,9 @@ def main():
         tmp = input("機械番号を入力してください（任意、例: P-55998。空でスキップ）: ").strip()
         machine_no = tmp or None
 
-    min_code_len = config.getint("merge", "min_code_len", fallback=6)
-
     drawing_to_candidates = load_candidates_xlsx(output_folder, order_no, machine_no)
     drawings_with_pdf = build_pdf_drawing_set(input_folder, order_no, machine_no)
+    drawings_with_dxf = build_dxf_drawing_set(input_folder, order_no, machine_no)
 
     if mode == "order":
         if "orders" not in config:
@@ -228,48 +260,30 @@ def main():
             order_code = normalize(row.iloc[col_order_code])
             cands = drawing_to_candidates.get(drawing, [])
             has_pdf = drawing in drawings_with_pdf
+            has_dxf = drawing in drawings_with_dxf
 
-            status = "OK"
-            proposed = ""
-
-            if has_pdf:
-                if is_blank(order_code):
-                    if len(cands) == 1:
-                        status = "AUTO"
-                        proposed = cands[0]
-                    elif len(cands) == 0:
-                        status = "MISSING"
-                    else:
-                        status = "REVIEW"
-                else:
-                    if order_code in cands:
-                        status = "OK"
-                    else:
-                        if can_autofill_prefix(order_code, cands, min_code_len):
-                            oc = str(order_code).strip()
-                            proposed = [c for c in cands if c.startswith(oc) and len(c) > len(oc)][0]
-                            status = "AUTO"
-                        else:
-                            status = "REVIEW" if len(cands) > 0 else "OK"
+            if not drawing:
+                status, reason_code, proposed = "ERROR", "DRAWING_NO_BLANK", ""
             else:
-                if is_blank(order_code) and len(cands) == 0:
-                    status = "MISSING_NO_PDF"
-                elif is_blank(order_code):
-                    status = "REVIEW_NO_PDF"
-                else:
-                    status = "OK"
+                status, reason_code, proposed = resolve_order_row(order_code, cands, has_dxf)
 
             rows.append({
-                "row_id": idx,
+                "row_index": idx,
                 "order_no": normalize(row.iloc[col_order_no]),
                 "juchu_no": normalize(row.iloc[col_juchu_no]),
                 "drawing_no": drawing,
                 "order_code": order_code,
                 "has_pdf": has_pdf,
+                "has_dxf": has_dxf,
                 "candidates": "|".join(cands),
                 "status": status,
+                "reason_code": reason_code,
                 "proposed_code": proposed,
             })
+            logging.info(
+                "row_index=%s drawing_no=%s status=%s reason_code=%s has_pdf=%s has_dxf=%s candidates=%s proposed=%s",
+                idx, drawing, status, reason_code, has_pdf, has_dxf, "|".join(cands), proposed
+            )
 
         df_check = pd.DataFrame(rows)
         check_path = os.path.join(output_folder, "check.csv")
@@ -278,7 +292,7 @@ def main():
         df_upload = df_order.copy()
         for r in rows:
             if r["status"] == "AUTO" and r["proposed_code"]:
-                df_upload.iat[r["row_id"], col_order_code] = r["proposed_code"]
+                df_upload.iat[r["row_index"], col_order_code] = r["proposed_code"]
 
         upload_path = os.path.join(output_folder, "upload.csv")
         df_upload.to_csv(upload_path, index=False, header=False, encoding="utf-8-sig")
@@ -286,21 +300,27 @@ def main():
         print(f"Saved: {check_path}")
         print(f"Saved: {upload_path}")
         print("AUTO件数:", int((df_check["status"] == "AUTO").sum()))
-        print("REVIEW件数:", int(df_check["status"].astype(str).str.startswith("REVIEW").sum()))
-        print("MISSING件数:", int(df_check["status"].astype(str).str.startswith("MISSING").sum()))
+        print("REVIEW件数:", int((df_check["status"] == "REVIEW").sum()))
+        print("ERROR件数:", int((df_check["status"] == "ERROR").sum()))
 
     else:
         out_rows = []
         for drawing, cands in sorted(drawing_to_candidates.items(), key=lambda x: x[0]):
             best = choose_best_candidate(cands)
             has_pdf = drawing in drawings_with_pdf
-            status = "AUTO" if has_pdf and len(cands) == 1 else ("REVIEW" if has_pdf and len(cands) > 1 else "NO_PDF")
+            status = "AUTO" if has_pdf and len(cands) == 1 else "REVIEW"
+            reason_code = (
+                "SINGLE_CANDIDATE_WITH_PDF" if has_pdf and len(cands) == 1
+                else "MULTI_CANDIDATE_WITH_PDF" if has_pdf and len(cands) > 1
+                else "NO_PDF_OR_NO_CANDIDATE"
+            )
             out_rows.append({
                 "drawing_no": drawing,
                 "has_pdf": has_pdf,
                 "candidates": "|".join(cands),
                 "best_candidate": best or "",
                 "status": status,
+                "reason_code": reason_code,
             })
         df_sum = pd.DataFrame(out_rows)
         sum_path = os.path.join(output_folder, "candidates_summary.csv")

--- a/pdf_combine_mode.py
+++ b/pdf_combine_mode.py
@@ -116,8 +116,13 @@ def read_ordered_drawings(config):
     if df.shape[1] <= col_drawing_no:
         raise ValueError(f"発注CSVの列数が不足しています。col_drawing_no={col_drawing_no}, actual_cols={df.shape[1]}")
 
-    drawings = [normalize(v) for v in df.iloc[:, col_drawing_no].tolist()]
-    return [d for d in drawings if d]
+    ordered_rows = []
+    for row_index, value in enumerate(df.iloc[:, col_drawing_no].tolist()):
+        ordered_rows.append({
+            "row_index": row_index,
+            "drawing_no": normalize(value),
+        })
+    return ordered_rows
 
 def combine_pdfs_order_mode(config, input_folder, output_folder, order_no, machine_no):
     os.makedirs(output_folder, exist_ok=True)
@@ -128,7 +133,7 @@ def combine_pdfs_order_mode(config, input_folder, output_folder, order_no, machi
         logging.warning("input_folder にPDFが見つかりません。")
         return
 
-    drawings = read_ordered_drawings(config)
+    ordered_rows = read_ordered_drawings(config)
 
     writer = PdfWriter()
     added_files = set()
@@ -136,9 +141,16 @@ def combine_pdfs_order_mode(config, input_folder, output_folder, order_no, machi
     missing = []
     multi = []
 
-    for d in drawings:
+    for item in ordered_rows:
+        row_index = item["row_index"]
+        d = item["drawing_no"]
+        if not d:
+            logging.warning(f"row_index={row_index}: drawing_no が空のためスキップ")
+            continue
+
         hits = match_pdfs_for_drawing(pdf_names, d, order_no, machine_no)
         if not hits:
+            logging.warning(f"row_index={row_index} drawing_no={d}: 対応PDFなし（継続）")
             missing.append(d)
             continue
         if len(hits) >= 2:
@@ -148,7 +160,7 @@ def combine_pdfs_order_mode(config, input_folder, output_folder, order_no, machi
             if fn in added_files:
                 continue
             path = os.path.join(input_folder, fn)
-            logging.info(f"[{d}] add: {fn}")
+            logging.info(f"row_index={row_index} drawing_no={d} add: {fn}")
             with open(path, "rb") as f:
                 reader = PdfReader(f)
                 for page in reader.pages:


### PR DESCRIPTION
### Motivation
- 注文CSVの行順（`row_index`）を唯一の順序キーとしてPDF結合の順序を厳密に保証し、欠落PDFでも処理を継続するための改修を行いました。 
- AUTO/REVIEW 判定ロジックを明確に分離して `reason_code` と `status`（`AUTO`/`REVIEW`/`ERROR`）を出力できる構造へ整理しました。

### Description
- 1) アーキテクチャ変更概要（文章図）: 
```
execute_scripts_with_step7.py (入口は維持)
  ├─ script_6: pdf_combine_mode.py
  │    ├─ read_ordered_drawings() -> [{row_index, drawing_no}]
  │    └─ combine_pdfs_order_mode() は row_index 順で結合し、PDF未存在は warning で継続
  └─ script_7: build_misumi_upload_csv.py
       ├─ build_pdf_drawing_set(), build_dxf_drawing_set()
       └─ resolve_order_row(order_code, cands, has_dxf) -> (status, reason_code, proposed)
```
- 2) モジュール分割方針: `pdf_combine_mode.py` は注文CSV読み取りを `read_ordered_drawings` に集約して `row_index` を保持し結合処理を行い、`build_misumi_upload_csv.py` は候補読み取り・DXF検出・判定を `build_*` と `resolve_order_row` に分離して `check.csv`/`upload.csv` 出力に注力します。 
- 3) 改修優先順位: (1) 注文CSV順の固定化、(2) 判定ロジック分離（`resolve_order_row`）、(3) `reason_code` とログ出力追加、(4) DXF条件付きの prefix 補完制御 の順で実施しました。 
- 4) 危険箇所: `match_pdfs_for_drawing` の既存の部分一致ロジックにより命名揺れがあると複数ヒットが発生し得る点と、既存の挙動（例えば「order_code と候補の一致を OK 扱いにしたい」要求）と今回の `REVIEW` 扱いの仕様差異に注意が必要です。 
- 5) 将来の異常検知の挿入ポイント: `resolve_order_row` の直後に閾値ベースの `ERROR` 昇格やパターン検査を差し込め、`pdf_combine_mode.py` の `if not hits` / `if len(hits) >= 2` ブロックで欠落率・重複率監視を追加できます。
- 実装の主要変更点は以下です: `build_misumi_upload_csv.py` に `build_dxf_drawing_set` と `resolve_order_row` を追加して `row_id` → `row_index` に統一し `has_dxf` を判定に用いるようにし、行ごとに `reason_code` を付与して `logging.info(...)` 出力を追加しました。`pdf_combine_mode.py` は `read_ordered_drawings()` が `[{row_index,drawing_no}]` を返すようにし、結合を必ず `row_index` 順で実行して欠落PDFは warning 出力のみで継続するように変更しました。

### Testing
- 実行時構文チェックとして `python -m py_compile build_misumi_upload_csv.py pdf_combine_mode.py execute_scripts_with_step7.py` を実行し、全ファイルのコンパイルチェックは成功しました。 
- 変更はローカルでコミット済みで、該当スクリプトの起動パス（`execute_scripts_with_step7.py` の呼び出し順）は維持しています。 
- ユニットテストは追加しておらず、動作検証は既存運用データでの確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9c7f5414832eaddbe5328fba9824)