### PR TITLE
[codex] Add workload dashboard and time-based work logs

### DIFF
--- a/apps/machine-process-visibility/backend/dashboard_service.py
+++ b/apps/machine-process-visibility/backend/dashboard_service.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+from fastapi import HTTPException
+
+from database import db
+from utils import validate_iso_date
+
+
+def period_range(period: str, base_date: str | None) -> tuple[str, str, str]:
+    target = date.fromisoformat(validate_iso_date(base_date, "基準日") or date.today().isoformat())
+    if period == "week":
+        start = target - timedelta(days=target.weekday())
+        end = start + timedelta(days=7)
+        label = f"{start.isoformat()}週"
+    elif period == "month":
+        start = target.replace(day=1)
+        end = date(start.year + (1 if start.month == 12 else 0), 1 if start.month == 12 else start.month + 1, 1)
+        label = f"{start.year}年{start.month}月"
+    else:
+        raise HTTPException(status_code=400, detail="集計単位は month または week を指定してください")
+    return start.isoformat(), end.isoformat(), label
+
+
+def list_workload(period: str = "month", base_date: str | None = None) -> dict[str, Any]:
+    start, end, label = period_range(period, base_date)
+    with db() as conn:
+        assignees = [dict(row) for row in conn.execute("SELECT * FROM assignees WHERE active = 1 ORDER BY id").fetchall()]
+        rows = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    wl.id,
+                    wl.work_date,
+                    wl.work_type,
+                    wl.completed_qty_delta,
+                    wl.duration_minutes,
+                    wl.estimated_minutes,
+                    wl.start_time,
+                    wl.end_time,
+                    wl.assignee_id,
+                    a.name AS assignee_name,
+                    p.name AS process_name,
+                    c.id AS card_id,
+                    c.order_no,
+                    c.item_type,
+                    c.drawing_no,
+                    c.item_name,
+                    cm.body AS comment_body
+                FROM work_logs wl
+                JOIN cards c ON c.id = wl.card_id
+                LEFT JOIN assignees a ON a.id = wl.assignee_id
+                LEFT JOIN processes p ON p.id = COALESCE(wl.process_id, c.current_process_id)
+                LEFT JOIN comments cm ON cm.id = wl.comment_id
+                WHERE wl.work_date >= ?
+                  AND wl.work_date < ?
+                  AND wl.work_type IN ('作業', '手戻り')
+                ORDER BY wl.work_date DESC, wl.created_at DESC, wl.id DESC
+                """,
+                (start, end),
+            ).fetchall()
+        ]
+
+    by_assignee: dict[int, dict[str, Any]] = {
+        assignee["id"]: {
+            "assignee": assignee,
+            "work_count": 0,
+            "completed_qty": 0,
+            "rework_count": 0,
+            "actual_minutes": 0,
+            "estimated_minutes": 0,
+            "variance_minutes": 0,
+            "efficiency_rate": None,
+            "processes": {},
+            "logs": [],
+        }
+        for assignee in assignees
+    }
+    for row in rows:
+        assignee_id = row["assignee_id"]
+        if assignee_id not in by_assignee:
+            continue
+        summary = by_assignee[assignee_id]
+        actual = int(row["duration_minutes"] or 0)
+        estimated = int(row["estimated_minutes"] or 0)
+        summary["work_count"] += 1
+        summary["completed_qty"] += max(int(row["completed_qty_delta"] or 0), 0)
+        summary["rework_count"] += 1 if row["work_type"] == "手戻り" else 0
+        summary["actual_minutes"] += actual
+        summary["estimated_minutes"] += estimated
+        process_name = row["process_name"] or "未設定"
+        process_summary = summary["processes"].setdefault(process_name, {"work_count": 0, "actual_minutes": 0, "estimated_minutes": 0})
+        process_summary["work_count"] += 1
+        process_summary["actual_minutes"] += actual
+        process_summary["estimated_minutes"] += estimated
+        summary["logs"].append(row)
+
+    summaries = []
+    for summary in by_assignee.values():
+        summary["variance_minutes"] = summary["estimated_minutes"] - summary["actual_minutes"]
+        if summary["estimated_minutes"] > 0:
+            summary["efficiency_rate"] = round((summary["actual_minutes"] / summary["estimated_minutes"]) * 100, 1)
+        summary["processes"] = [
+            {"name": name, **values}
+            for name, values in sorted(summary["processes"].items(), key=lambda item: item[0])
+        ]
+        summaries.append(summary)
+
+    return {
+        "period": period,
+        "label": label,
+        "start_date": start,
+        "end_date": (date.fromisoformat(end) - timedelta(days=1)).isoformat(),
+        "summaries": summaries,
+    }

--- a/apps/machine-process-visibility/backend/main.py
+++ b/apps/machine-process-visibility/backend/main.py
@@ -9,6 +9,7 @@ from migrations import init_db
 from routers.admin import router as admin_router
 from routers.auth import router as auth_router
 from routers.cards import router as cards_router
+from routers.dashboard import router as dashboard_router
 from routers.meta import router as meta_router
 from routers.reports import router as reports_router
 
@@ -26,6 +27,7 @@ app.include_router(meta_router)
 app.include_router(admin_router)
 app.include_router(auth_router)
 app.include_router(cards_router)
+app.include_router(dashboard_router)
 app.include_router(reports_router)
 
 

--- a/apps/machine-process-visibility/backend/migrations.py
+++ b/apps/machine-process-visibility/backend/migrations.py
@@ -232,6 +232,10 @@ def init_db() -> None:
                 work_date TEXT NOT NULL,
                 completed_qty_delta INTEGER NOT NULL,
                 work_hours REAL NOT NULL CHECK(work_hours >= 0),
+                start_time TEXT,
+                end_time TEXT,
+                duration_minutes INTEGER NOT NULL DEFAULT 0 CHECK(duration_minutes >= 0),
+                estimated_minutes INTEGER NOT NULL DEFAULT 0 CHECK(estimated_minutes >= 0),
                 comment_id INTEGER REFERENCES comments(id),
                 created_at TEXT NOT NULL
             );
@@ -271,6 +275,10 @@ def init_db() -> None:
         ensure_column(conn, "work_logs", "process_id", "INTEGER REFERENCES processes(id)")
         ensure_column(conn, "work_logs", "registered_by_user_id", "INTEGER REFERENCES users(id)")
         ensure_column(conn, "work_logs", "work_type", "TEXT NOT NULL DEFAULT '作業'")
+        ensure_column(conn, "work_logs", "start_time", "TEXT")
+        ensure_column(conn, "work_logs", "end_time", "TEXT")
+        ensure_column(conn, "work_logs", "duration_minutes", "INTEGER NOT NULL DEFAULT 0")
+        ensure_column(conn, "work_logs", "estimated_minutes", "INTEGER NOT NULL DEFAULT 0")
         allow_negative_work_log_delta(conn)
         sync_comment_classification_constraint(conn)
         conn.execute(
@@ -386,5 +394,66 @@ def init_db() -> None:
                 """,
                 users,
             )
+
+        conn.execute(
+            """
+            UPDATE work_logs
+            SET duration_minutes = CAST(ROUND(work_hours * 60) AS INTEGER)
+            WHERE duration_minutes = 0 AND work_hours > 0
+            """
+        )
+
+        if not table_has_rows(conn, "work_logs"):
+            seed_logs = [
+                ("SH-208500L2", "三谷", "内面研磨", "作業", today.isoformat(), 6, "08:30", "10:15", 120, ""),
+                ("SH-208500L2", "三谷", "内面研磨", "作業", today.isoformat(), 5, "10:30", "12:00", 90, ""),
+                ("SH-208500L2", "山本", "内面研磨", "手戻り", today.isoformat(), -1, "13:00", "13:45", 30, "寸法再確認"),
+                ("HB-110470", "山本", "刃物研磨", "作業", (today - timedelta(days=3)).isoformat(), 3, "09:00", "10:10", 80, ""),
+                ("RW-001", "佐藤", "機械加工", "作業", (today - timedelta(days=8)).isoformat(), 1, "14:00", "15:20", 75, ""),
+                ("RW-001", "鈴木", "機械加工", "作業", (today - timedelta(days=15)).isoformat(), 1, "16:00", "17:05", 60, ""),
+            ]
+            for drawing_no, assignee_name, process_name, work_type, work_date, qty_delta, start_time, end_time, estimated, comment in seed_logs:
+                card = conn.execute("SELECT id FROM cards WHERE drawing_no = ?", (drawing_no,)).fetchone()
+                assignee = conn.execute("SELECT id FROM assignees WHERE name = ?", (assignee_name,)).fetchone()
+                process = conn.execute("SELECT id FROM processes WHERE name = ?", (process_name,)).fetchone()
+                user = conn.execute("SELECT id FROM users WHERE assignee_id = ?", (assignee["id"],)).fetchone() if assignee else None
+                if not card or not assignee or not process:
+                    continue
+                start_hour, start_minute = [int(part) for part in start_time.split(":")]
+                end_hour, end_minute = [int(part) for part in end_time.split(":")]
+                duration_minutes = (end_hour * 60 + end_minute) - (start_hour * 60 + start_minute)
+                comment_id = None
+                if comment:
+                    cur = conn.execute(
+                        "INSERT INTO comments(card_id, comment_type, body, user_id, created_at) VALUES (?, ?, ?, ?, ?)",
+                        (card["id"], work_type, comment, assignee["id"], now_iso()),
+                    )
+                    comment_id = cur.lastrowid
+                conn.execute(
+                    """
+                    INSERT INTO work_logs(
+                        card_id, assignee_id, registered_by_user_id, process_id, work_type, work_date,
+                        completed_qty_delta, work_hours, start_time, end_time, duration_minutes, estimated_minutes,
+                        comment_id, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card["id"],
+                        assignee["id"],
+                        user["id"] if user else None,
+                        process["id"],
+                        work_type,
+                        work_date,
+                        qty_delta,
+                        round(duration_minutes / 60, 2),
+                        start_time,
+                        end_time,
+                        duration_minutes,
+                        estimated,
+                        comment_id,
+                        now_iso(),
+                    ),
+                )
 
         normalize_existing_poc_data(conn)

--- a/apps/machine-process-visibility/backend/routers/dashboard.py
+++ b/apps/machine-process-visibility/backend/routers/dashboard.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from auth import require_admin, require_ready_user
+from dashboard_service import list_workload
+
+
+router = APIRouter(prefix="/api/dashboard")
+
+
+@router.get("/workload")
+def workload(
+    period: str = Query("month"),
+    base_date: Optional[str] = Query(None),
+    user: dict[str, Any] = Depends(require_ready_user),
+) -> dict[str, Any]:
+    require_admin(user)
+    return list_workload(period=period, base_date=base_date)

--- a/apps/machine-process-visibility/backend/schemas.py
+++ b/apps/machine-process-visibility/backend/schemas.py
@@ -32,7 +32,10 @@ class CommentPayload(BaseModel):
 
 class WorkResultPayload(BaseModel):
     completed_qty_delta: int
-    work_hours: float = Field(ge=0)
+    work_hours: float = Field(ge=0, default=0)
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    estimated_minutes: int = Field(ge=0, default=0)
     assignee_id: Optional[int] = None
     work_date: Optional[str] = None
     comment_type: str = "作業"

--- a/apps/machine-process-visibility/backend/tests/test_card_query_service.py
+++ b/apps/machine-process-visibility/backend/tests/test_card_query_service.py
@@ -63,8 +63,8 @@ def test_get_card_detail_includes_comments_and_work_logs(initialized_db: Path) -
 
     detail = get_card_detail(card["id"])
 
-    assert detail["comments"][0]["body"] == "確認済み"
-    assert detail["work_logs"][0]["comment_body"] == "確認済み"
+    assert any(comment["body"] == "確認済み" for comment in detail["comments"])
+    assert any(log["comment_body"] == "確認済み" for log in detail["work_logs"])
 
 
 def test_get_card_detail_raises_404_for_unknown_card(initialized_db: Path) -> None:

--- a/apps/machine-process-visibility/backend/tests/test_dashboard_service.py
+++ b/apps/machine-process-visibility/backend/tests/test_dashboard_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import date
+
+from dashboard_service import list_workload, period_range
+
+
+def test_period_range_week_starts_on_monday() -> None:
+    start, end, label = period_range("week", "2026-05-07")
+
+    assert start == "2026-05-04"
+    assert end == "2026-05-11"
+    assert label == "2026-05-04週"
+
+
+def test_workload_returns_assignee_summaries(initialized_db: Path) -> None:
+    result = list_workload(period="month", base_date=date.today().isoformat())
+
+    assert result["period"] == "month"
+    assert result["summaries"]
+    mitani = next(summary for summary in result["summaries"] if summary["assignee"]["name"] == "三谷")
+    assert mitani["work_count"] >= 1
+    assert mitani["actual_minutes"] > 0
+    assert "variance_minutes" in mitani

--- a/apps/machine-process-visibility/backend/tests/test_migrations_normalization.py
+++ b/apps/machine-process-visibility/backend/tests/test_migrations_normalization.py
@@ -37,6 +37,7 @@ def test_init_db_normalizes_existing_invalid_poc_card_data(initialized_db: Path)
 def test_init_db_removes_invalid_work_logs(initialized_db: Path) -> None:
     card = fetch_one("SELECT * FROM cards WHERE drawing_no = ?", ("SH-208500L2",))
     assignee = fetch_one("SELECT * FROM assignees WHERE name = ?", ("三谷",))
+    before_valid_count = len(fetch_all("SELECT * FROM work_logs WHERE card_id = ?", (card["id"],)))
     with db() as conn:
         conn.execute(
             """
@@ -58,7 +59,7 @@ def test_init_db_removes_invalid_work_logs(initialized_db: Path) -> None:
                 "2026-05-05T10:00:00",
             ),
         )
-
     init_db()
 
-    assert fetch_all("SELECT * FROM work_logs WHERE card_id = ?", (card["id"],)) == []
+    after_count = len(fetch_all("SELECT * FROM work_logs WHERE card_id = ?", (card["id"],)))
+    assert after_count == before_valid_count

--- a/apps/machine-process-visibility/backend/tests/test_work_result_service.py
+++ b/apps/machine-process-visibility/backend/tests/test_work_result_service.py
@@ -22,7 +22,9 @@ def test_register_work_result_completes_card_and_writes_log_and_audit(initialize
     user = user_by_username("yamamoto")
     payload = WorkResultPayload(
         completed_qty_delta=8,
-        work_hours=2.5,
+        start_time="08:00",
+        end_time="10:30",
+        estimated_minutes=150,
         assignee_id=user["assignee_id"],
         work_date="2026-05-05",
         comment_type="作業",
@@ -35,6 +37,8 @@ def test_register_work_result_completes_card_and_writes_log_and_audit(initialize
     assert result["status"] == "完了"
     assert result["work_logs"][0]["completed_qty_delta"] == 8
     assert result["work_logs"][0]["work_hours"] == 2.5
+    assert result["work_logs"][0]["duration_minutes"] == 150
+    assert result["work_logs"][0]["estimated_minutes"] == 150
 
     audit = fetch_one("SELECT * FROM card_audit_logs WHERE card_id = ?", (card["id"],))
     assert audit["action"] == "completed_qty_from_work_log"
@@ -51,7 +55,8 @@ def test_rework_requires_negative_delta_and_comment(initialized_db: Path) -> Non
             card["id"],
             WorkResultPayload(
                 completed_qty_delta=-1,
-                work_hours=0,
+                start_time="13:00",
+                end_time="13:30",
                 assignee_id=user["assignee_id"],
                 work_date="2026-05-05",
                 comment_type="手戻り",
@@ -65,7 +70,9 @@ def test_rework_requires_negative_delta_and_comment(initialized_db: Path) -> Non
         card["id"],
         WorkResultPayload(
             completed_qty_delta=-1,
-            work_hours=0,
+            start_time="13:00",
+            end_time="13:30",
+            estimated_minutes=30,
             assignee_id=user["assignee_id"],
             work_date="2026-05-05",
             comment_type="手戻り",
@@ -90,7 +97,8 @@ def test_operator_cannot_register_work_for_other_assignee(initialized_db: Path) 
             card["id"],
             WorkResultPayload(
                 completed_qty_delta=1,
-                work_hours=1,
+                start_time="09:00",
+                end_time="10:00",
                 assignee_id=other_assignee["id"],
                 work_date="2026-05-05",
                 comment_type="作業",
@@ -111,7 +119,52 @@ def test_completed_quantity_cannot_exceed_total(initialized_db: Path) -> None:
             card["id"],
             WorkResultPayload(
                 completed_qty_delta=9,
-                work_hours=1,
+                start_time="09:00",
+                end_time="10:00",
+                assignee_id=user["assignee_id"],
+                work_date="2026-05-05",
+                comment_type="作業",
+                comment="",
+            ),
+            user,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_work_time_must_be_within_business_hours(initialized_db: Path) -> None:
+    card = card_by_drawing_no("HB-110470")
+    user = user_by_username("yamamoto")
+
+    with pytest.raises(HTTPException) as exc_info:
+        register_work_result_for_card(
+            card["id"],
+            WorkResultPayload(
+                completed_qty_delta=1,
+                start_time="07:50",
+                end_time="08:30",
+                assignee_id=user["assignee_id"],
+                work_date="2026-05-05",
+                comment_type="作業",
+                comment="",
+            ),
+            user,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_end_time_must_be_after_start_time(initialized_db: Path) -> None:
+    card = card_by_drawing_no("HB-110470")
+    user = user_by_username("yamamoto")
+
+    with pytest.raises(HTTPException) as exc_info:
+        register_work_result_for_card(
+            card["id"],
+            WorkResultPayload(
+                completed_qty_delta=1,
+                start_time="10:00",
+                end_time="09:59",
                 assignee_id=user["assignee_id"],
                 work_date="2026-05-05",
                 comment_type="作業",

--- a/apps/machine-process-visibility/backend/work_result_service.py
+++ b/apps/machine-process-visibility/backend/work_result_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import date
 from typing import Any
 
@@ -13,6 +14,10 @@ from database import db
 from schemas import WorkResultPayload
 from utils import now_iso, validate_iso_date
 
+TIME_PATTERN = re.compile(r"^([01]\d|2[0-3]):([0-5]\d)$")
+WORK_START_MINUTES = 8 * 60
+WORK_END_MINUTES = 22 * 60
+
 
 def status_for_completed_qty(completed_qty: int, total_qty: int) -> str:
     if completed_qty >= total_qty:
@@ -22,30 +27,53 @@ def status_for_completed_qty(completed_qty: int, total_qty: int) -> str:
     return "未着手"
 
 
-def validate_work_result_payload(payload: WorkResultPayload) -> tuple[str, str, str]:
+def time_to_minutes(value: str, field_name: str) -> int:
+    if not TIME_PATTERN.fullmatch(value):
+        raise HTTPException(status_code=400, detail=f"{field_name}は HH:MM 形式で入力してください")
+    hour, minute = value.split(":")
+    return int(hour) * 60 + int(minute)
+
+
+def duration_minutes_from_range(start_time: str | None, end_time: str | None) -> int:
+    if not start_time or not end_time:
+        raise HTTPException(status_code=400, detail="作業の場合は開始時刻と終了時刻を入力してください")
+    start_minutes = time_to_minutes(start_time, "開始時刻")
+    end_minutes = time_to_minutes(end_time, "終了時刻")
+    if start_minutes < WORK_START_MINUTES or end_minutes > WORK_END_MINUTES:
+        raise HTTPException(status_code=400, detail="作業時刻は08:00〜22:00の範囲で入力してください")
+    if end_minutes <= start_minutes:
+        raise HTTPException(status_code=400, detail="終了時刻は開始時刻より後にしてください")
+    return end_minutes - start_minutes
+
+
+def validate_work_result_payload(payload: WorkResultPayload) -> tuple[str, str, str, int]:
     if payload.comment_type not in COMMENT_TYPES:
         raise HTTPException(status_code=400, detail="不正な作業分類です")
 
     work_date = validate_iso_date(payload.work_date, "作業日") or date.today().isoformat()
     work_type = payload.comment_type
     comment_body = payload.comment.strip()
+    records_work_time = work_type in {"作業", "手戻り"}
+    duration_minutes = duration_minutes_from_range(payload.start_time, payload.end_time) if records_work_time else 0
 
     if payload.completed_qty_delta < 0 and work_type != "手戻り":
         raise HTTPException(status_code=400, detail="加工数量のマイナス入力は作業分類が手戻りの場合のみ可能です")
-    if work_type == "作業" and (payload.completed_qty_delta <= 0 or payload.work_hours <= 0):
-        raise HTTPException(status_code=400, detail="作業の場合は加工数量と作業時間を入力してください")
+    if work_type == "作業" and payload.completed_qty_delta <= 0:
+        raise HTTPException(status_code=400, detail="作業の場合は加工数量を入力してください")
     if work_type == "手戻り" and (payload.completed_qty_delta >= 0 or not comment_body):
         raise HTTPException(status_code=400, detail="手戻りの場合はマイナスの加工数量と理由コメントを入力してください")
-    if work_type == "コメント" and (payload.completed_qty_delta != 0 or payload.work_hours != 0 or not comment_body):
-        raise HTTPException(status_code=400, detail="コメントの場合は加工数量と作業時間を0にしてコメントを入力してください")
-    if work_type == "開始" and (payload.completed_qty_delta != 0 or payload.work_hours != 0):
-        raise HTTPException(status_code=400, detail="開始の場合は加工数量と作業時間を0にしてください")
+    if work_type == "コメント" and (payload.completed_qty_delta != 0 or not comment_body):
+        raise HTTPException(status_code=400, detail="コメントの場合は加工数量を0にしてコメントを入力してください")
+    if work_type in {"開始", "コメント"} and (payload.start_time or payload.end_time or payload.estimated_minutes):
+        raise HTTPException(status_code=400, detail="開始・コメントの場合は作業時刻と見積時間を入力しないでください")
+    if work_type == "開始" and payload.completed_qty_delta != 0:
+        raise HTTPException(status_code=400, detail="開始の場合は加工数量を0にしてください")
 
-    return work_date, work_type, comment_body
+    return work_date, work_type, comment_body, duration_minutes
 
 
 def register_work_result_for_card(card_id: int, payload: WorkResultPayload, user: dict[str, Any]) -> dict[str, Any]:
-    work_date, work_type, comment_body = validate_work_result_payload(payload)
+    work_date, work_type, comment_body, duration_minutes = validate_work_result_payload(payload)
     if payload.assignee_id and payload.assignee_id != user["assignee_id"]:
         require_admin(user)
 
@@ -75,9 +103,10 @@ def register_work_result_for_card(card_id: int, payload: WorkResultPayload, user
             """
             INSERT INTO work_logs(
                 card_id, assignee_id, registered_by_user_id, process_id, work_type, work_date,
-                completed_qty_delta, work_hours, comment_id, created_at
+                completed_qty_delta, work_hours, start_time, end_time, duration_minutes, estimated_minutes,
+                comment_id, created_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 card_id,
@@ -87,7 +116,11 @@ def register_work_result_for_card(card_id: int, payload: WorkResultPayload, user
                 work_type,
                 work_date,
                 payload.completed_qty_delta,
-                payload.work_hours,
+                round(duration_minutes / 60, 2),
+                payload.start_time,
+                payload.end_time,
+                duration_minutes,
+                payload.estimated_minutes if work_type in {"作業", "手戻り"} else 0,
                 comment_id,
                 now_iso(),
             ),

--- a/apps/machine-process-visibility/src/App.tsx
+++ b/apps/machine-process-visibility/src/App.tsx
@@ -7,10 +7,10 @@ import { AssigneeView } from "./views/AssigneeView";
 import { AdminView } from "./views/AdminView";
 import { BoardView } from "./views/BoardView";
 import { CalendarView } from "./views/CalendarView";
+import { DashboardView } from "./views/DashboardView";
 import { LoginView } from "./views/LoginView";
 import { PasswordChangeView } from "./views/PasswordChangeView";
 import { ProcessView } from "./views/ProcessView";
-import { ReportView } from "./views/ReportView";
 
 export function App() {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -154,7 +154,7 @@ export function App() {
             ["process", "島別"],
             ["assignee", "担当者別"],
             ["calendar", "カレンダー"],
-            ["report", "日報"],
+            ...(isAdmin ? [["dashboard", "ダッシュボード"]] : []),
             ...(isAdmin ? [["admin", "管理"]] : []),
           ].map(([key, label]) => (
             <button key={key} className={view === key ? "active" : ""} onClick={() => setView(key as View)}>
@@ -196,7 +196,7 @@ export function App() {
         )}
         {view === "assignee" && <AssigneeView cards={visibleCards} assignees={meta.assignees} onOpen={openCard} />}
         {view === "calendar" && <CalendarView cards={visibleCards} onOpen={openCard} />}
-        {view === "report" && <ReportView meta={meta} />}
+        {view === "dashboard" && isAdmin && <DashboardView />}
         {view === "admin" && isAdmin && <AdminView meta={meta} onMetaChanged={load} />}
       </main>
 

--- a/apps/machine-process-visibility/src/components/CardModal.tsx
+++ b/apps/machine-process-visibility/src/components/CardModal.tsx
@@ -3,7 +3,7 @@ import { request } from "../api";
 import { DateField } from "./DateField";
 import type { AuthUser, Card, CardDraft, Meta, WorkFormState } from "../types";
 import { labelStyle, toPayload } from "../utils/card";
-import { localDateString } from "../utils/date";
+import { localDateString, minutesLabel } from "../utils/date";
 
 export function CardModal({
   card,
@@ -26,12 +26,15 @@ export function CardModal({
     work_date: localDateString(),
     completed_qty_delta: 0,
     work_hours: 0,
+    start_time: "08:00",
+    end_time: "09:00",
+    estimated_minutes: 60,
     assignee_id: currentUser.assignee_id ?? card.assignee_id ?? meta.assignees[0]?.id ?? null,
     comment_type: "作業",
     comment: "",
   });
   const [workQtyText, setWorkQtyText] = useState("0");
-  const [workHoursText, setWorkHoursText] = useState("0");
+  const [estimatedMinutesText, setEstimatedMinutesText] = useState("60");
   const [error, setError] = useState("");
 
   async function save(event: FormEvent) {
@@ -59,19 +62,23 @@ export function CardModal({
         body: JSON.stringify({
           ...work,
           completed_qty_delta: Number(workQtyText || 0),
-          work_hours: Number(workHoursText || 0),
+          work_hours: actualWorkMinutes / 60,
+          estimated_minutes: Number(estimatedMinutesText || 0),
         }),
       });
       setWork({
         work_date: localDateString(),
         completed_qty_delta: 0,
         work_hours: 0,
+        start_time: "08:00",
+        end_time: "09:00",
+        estimated_minutes: 60,
         assignee_id: currentUser.assignee_id ?? draft.assignee_id ?? meta.assignees[0]?.id ?? null,
         comment_type: "作業",
         comment: "",
       });
       setWorkQtyText("0");
-      setWorkHoursText("0");
+      setEstimatedMinutesText("60");
       onSaved(cardId);
     } catch (err) {
       setError((err as Error).message);
@@ -86,24 +93,44 @@ export function CardModal({
     setWork({ ...work, comment_type: value });
     if (value === "開始" || value === "コメント") {
       setWorkQtyText("0");
-      setWorkHoursText("0");
+      setEstimatedMinutesText("0");
+    } else {
+      setEstimatedMinutesText((current) => current === "0" ? "60" : current);
     }
   }
 
   const adminOnlyDisabled = !isAdmin;
   const workerSelectDisabled = !isAdmin;
   const zeroWorkInputs = work.comment_type === "開始" || work.comment_type === "コメント";
+  const recordsWorkTime = work.comment_type === "作業" || work.comment_type === "手戻り";
   const workQty = Number(workQtyText || 0);
-  const workHours = Number(workHoursText || 0);
+  const estimatedMinutes = Number(estimatedMinutesText || 0);
   const workComment = work.comment.trim();
+  const startMinutes = /^([01]\d|2[0-3]):[0-5]\d$/.test(work.start_time) ? Number(work.start_time.slice(0, 2)) * 60 + Number(work.start_time.slice(3)) : NaN;
+  const endMinutes = /^([01]\d|2[0-3]):[0-5]\d$/.test(work.end_time) ? Number(work.end_time.slice(0, 2)) * 60 + Number(work.end_time.slice(3)) : NaN;
+  const actualWorkMinutes = recordsWorkTime && Number.isFinite(startMinutes) && Number.isFinite(endMinutes) ? endMinutes - startMinutes : 0;
+  const timeValidationMessage = recordsWorkTime
+    ? !work.start_time || !work.end_time
+      ? "開始時刻と終了時刻を入力してください"
+      : !Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)
+        ? "時刻は HH:MM 形式で入力してください"
+        : startMinutes < 8 * 60 || endMinutes > 22 * 60
+          ? "作業時刻は08:00〜22:00の範囲で入力してください"
+          : actualWorkMinutes <= 0
+            ? "終了時刻は開始時刻より後にしてください"
+            : ""
+    : "";
   const workValidationMessage =
-    work.comment_type === "作業" && (workQty <= 0 || workHours <= 0)
-      ? "作業は加工数量と作業時間を入力してください"
+    timeValidationMessage ||
+    (work.comment_type === "作業" && workQty <= 0
+      ? "作業は加工数量を入力してください"
       : work.comment_type === "手戻り" && (workQty >= 0 || !workComment)
         ? "手戻りはマイナス数量と理由コメントを入力してください"
         : work.comment_type === "コメント" && !workComment
           ? "コメントを入力してください"
-          : "";
+          : recordsWorkTime && estimatedMinutes < 0
+            ? "見積時間は0分以上で入力してください"
+            : "");
   const workSubmitDisabled = Boolean(workValidationMessage);
 
   return (
@@ -146,15 +173,39 @@ export function CardModal({
               />
             </label>
             <label>
-              作業時間(h)
+              開始時刻
+              <input
+                type="time"
+                min="08:00"
+                max="22:00"
+                step="60"
+                value={work.start_time}
+                disabled={zeroWorkInputs}
+                onChange={(e) => setWork({ ...work, start_time: e.target.value })}
+              />
+            </label>
+            <label>
+              終了時刻
+              <input
+                type="time"
+                min="08:00"
+                max="22:00"
+                step="60"
+                value={work.end_time}
+                disabled={zeroWorkInputs}
+                onChange={(e) => setWork({ ...work, end_time: e.target.value })}
+              />
+            </label>
+            <label>
+              見積時間(分)
               <input
                 type="text"
-                inputMode="decimal"
-                placeholder="例: 1.5"
-                value={workHoursText}
+                inputMode="numeric"
+                placeholder="例: 60"
+                value={estimatedMinutesText}
                 disabled={zeroWorkInputs}
                 onFocus={(event) => event.currentTarget.select()}
-                onChange={(e) => setWorkHoursText(e.target.value)}
+                onChange={(e) => setEstimatedMinutesText(e.target.value.replace(/\D/g, ""))}
               />
             </label>
             <label>
@@ -167,6 +218,7 @@ export function CardModal({
               コメント
               <input placeholder="手戻り・コメント時は必須" value={work.comment} onChange={(e) => setWork({ ...work, comment: e.target.value })} />
             </label>
+            {recordsWorkTime && !timeValidationMessage && <p className="formHint">実作業時間: {minutesLabel(actualWorkMinutes)} / 見積差分: {minutesLabel(estimatedMinutes - actualWorkMinutes)}</p>}
             {workValidationMessage && <p className="formHint">{workValidationMessage}</p>}
             <button type="submit" disabled={workSubmitDisabled}>登録</button>
           </form>
@@ -231,7 +283,7 @@ export function CardModal({
               <h3>作業ログ</h3>
               <div className="tableScroll">
                 <table>
-                  <thead><tr><th>日付</th><th>担当</th><th>作業分類</th><th>加工数量</th><th>時間(h)</th><th>コメント</th></tr></thead>
+                  <thead><tr><th>日付</th><th>担当</th><th>作業分類</th><th>加工数量</th><th>開始</th><th>終了</th><th>実績</th><th>見積</th><th>コメント</th></tr></thead>
                   <tbody>
                     {(card.work_logs ?? []).map((log) => (
                       <tr key={log.id}>
@@ -239,7 +291,10 @@ export function CardModal({
                         <td>{log.assignee_name ?? "-"}</td>
                         <td>{log.comment_type ?? "-"}</td>
                         <td>{log.completed_qty_delta}</td>
-                        <td>{log.work_hours}</td>
+                        <td>{log.start_time ?? "-"}</td>
+                        <td>{log.end_time ?? "-"}</td>
+                        <td>{minutesLabel(log.duration_minutes ?? Math.round((log.work_hours ?? 0) * 60))}</td>
+                        <td>{minutesLabel(log.estimated_minutes ?? 0)}</td>
                         <td>{log.comment_body ?? ""}</td>
                       </tr>
                     ))}

--- a/apps/machine-process-visibility/src/styles.css
+++ b/apps/machine-process-visibility/src/styles.css
@@ -551,6 +551,25 @@ tbody tr:hover {
   min-width: 150px;
 }
 
+.segmented {
+  display: inline-flex;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.segmented button {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.segmented button.active {
+  background: #2563eb;
+  color: #ffffff;
+}
+
 .monthCalendar {
   display: grid;
   grid-template-columns: repeat(7, minmax(120px, 1fr));
@@ -583,6 +602,10 @@ tbody tr:hover {
 .dayCell {
   min-height: 132px;
   padding: 8px;
+}
+
+.weekCalendar .dayCell {
+  min-height: 360px;
 }
 
 .dayCell.empty {
@@ -807,7 +830,7 @@ label textarea,
 
 .workForm {
   display: grid;
-  grid-template-columns: 1.2fr 1fr 1fr 1fr 2fr auto;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
   gap: 10px;
   align-items: end;
   padding: 12px;
@@ -893,6 +916,112 @@ label textarea,
 
 .report {
   min-width: 1120px;
+}
+
+.dashboardToolbar,
+.detailHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dashboardToolbar h2,
+.dashboardToolbar p,
+.detailHeader h3 {
+  margin: 0;
+}
+
+.dashboardToolbar p {
+  color: #64748b;
+  margin-top: 4px;
+}
+
+.dashboardToolbar input {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.summaryStrip {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 14px 0;
+}
+
+.summaryStrip span {
+  border: 1px solid #dbe3ec;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #f8fafc;
+  color: #475569;
+}
+
+.summaryStrip strong {
+  color: #0f172a;
+  margin-left: 6px;
+}
+
+.assigneeMetrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.metricCard {
+  display: grid;
+  gap: 5px;
+  text-align: left;
+  border: 1px solid #dbe3ec;
+  background: #ffffff;
+  padding: 12px;
+}
+
+.metricCard.active {
+  border-color: #2563eb;
+  box-shadow: inset 0 0 0 1px #2563eb;
+}
+
+.metricCard small {
+  color: #64748b;
+}
+
+.assigneeDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.positive {
+  color: #166534;
+}
+
+.negative {
+  color: #b91c1c;
+}
+
+.dashboardDetail {
+  border-top: 1px solid #e2e8f0;
+  padding-top: 14px;
+}
+
+.processBreakdown {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.processBreakdown div {
+  display: grid;
+  grid-template-columns: 1.5fr repeat(3, 1fr);
+  gap: 8px;
+  border: 1px solid #dbe3ec;
+  border-radius: 8px;
+  padding: 10px;
+  background: #f8fafc;
 }
 
 @media (max-width: 900px) {

--- a/apps/machine-process-visibility/src/types.ts
+++ b/apps/machine-process-visibility/src/types.ts
@@ -38,6 +38,10 @@ export type WorkLog = {
   work_date: string;
   completed_qty_delta: number;
   work_hours: number;
+  start_time: string | null;
+  end_time: string | null;
+  duration_minutes: number;
+  estimated_minutes: number;
   assignee_name?: string;
   comment_type?: string;
   comment_body?: string;
@@ -62,7 +66,47 @@ export type ReportRow = {
 };
 
 export type Meta = { processes: Process[]; assignees: Assignee[]; tags: Tag[]; comment_types: string[] };
-export type View = "board" | "process" | "assignee" | "calendar" | "report" | "admin";
+export type DashboardPeriod = "month" | "week";
+
+export type DashboardLog = WorkLog & {
+  work_type: string;
+  assignee_id: number;
+  process_name: string;
+  card_id: number;
+  order_no: string;
+  item_type: string;
+  drawing_no: string;
+  item_name: string;
+};
+
+export type DashboardProcessSummary = {
+  name: string;
+  work_count: number;
+  actual_minutes: number;
+  estimated_minutes: number;
+};
+
+export type DashboardAssigneeSummary = {
+  assignee: Assignee;
+  work_count: number;
+  completed_qty: number;
+  rework_count: number;
+  actual_minutes: number;
+  estimated_minutes: number;
+  variance_minutes: number;
+  efficiency_rate: number | null;
+  processes: DashboardProcessSummary[];
+  logs: DashboardLog[];
+};
+
+export type DashboardResponse = {
+  period: DashboardPeriod;
+  label: string;
+  start_date: string;
+  end_date: string;
+  summaries: DashboardAssigneeSummary[];
+};
+export type View = "board" | "process" | "assignee" | "calendar" | "dashboard" | "report" | "admin";
 export type ProcessSortMode = "due" | "assignee";
 
 export type AuthUser = {
@@ -94,6 +138,9 @@ export type WorkFormState = {
   work_date: string;
   completed_qty_delta: number;
   work_hours: number;
+  start_time: string;
+  end_time: string;
+  estimated_minutes: number;
   assignee_id: number | null;
   comment_type: string;
   comment: string;

--- a/apps/machine-process-visibility/src/utils/date.ts
+++ b/apps/machine-process-visibility/src/utils/date.ts
@@ -10,6 +10,24 @@ export function monthKey(date: Date) {
   return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}`;
 }
 
+export function addDays(date: Date, days: number) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+export function mondayOfWeek(date: Date) {
+  const day = date.getDay();
+  const delta = day === 0 ? -6 : 1 - day;
+  return addDays(date, delta);
+}
+
+export function minutesLabel(minutes: number) {
+  const sign = minutes < 0 ? "-" : "";
+  const value = Math.abs(minutes);
+  const hours = Math.floor(value / 60);
+  const rest = value % 60;
+  return `${sign}${hours}h${pad2(rest)}m`;
+}
+
 export function normalizeDateInput(raw: string) {
   const value = raw.trim();
   if (!value) return "";

--- a/apps/machine-process-visibility/src/views/CalendarView.tsx
+++ b/apps/machine-process-visibility/src/views/CalendarView.tsx
@@ -1,24 +1,30 @@
 import { useState } from "react";
 import type { Card } from "../types";
 import { isRework } from "../utils/card";
-import { localDateString, monthKey, pad2 } from "../utils/date";
+import { addDays, localDateString, mondayOfWeek, monthKey, pad2 } from "../utils/date";
 
 export function CalendarView({ cards, onOpen }: { cards: Card[]; onOpen: (id: number) => void }) {
   const [displayMonth, setDisplayMonth] = useState(() => {
     const today = new Date();
     return new Date(today.getFullYear(), today.getMonth(), 1);
   });
+  const [displayWeek, setDisplayWeek] = useState(() => mondayOfWeek(new Date()));
+  const [mode, setMode] = useState<"month" | "week">("month");
   const todayKey = localDateString();
   const currentMonthKey = monthKey(displayMonth);
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  const weekdays = mode === "month" ? ["日", "月", "火", "水", "木", "金", "土"] : ["月", "火", "水", "木", "金", "土", "日"];
   const entriesByDay = new Map<string, { card: Card; kind: "予定" | "納期" }[]>();
+  const weekDays = Array.from({ length: 7 }, (_, index) => localDateString(addDays(displayWeek, index)));
+  const visibleDaySet = new Set(mode === "month" ? [] : weekDays);
 
   cards.forEach((card) => {
     [
       { day: card.planned_work_date, kind: "予定" as const },
       { day: card.due_date, kind: "納期" as const },
     ].forEach(({ day, kind }) => {
-      if (!day || !day.startsWith(currentMonthKey)) return;
+      if (!day) return;
+      if (mode === "month" && !day.startsWith(currentMonthKey)) return;
+      if (mode === "week" && !visibleDaySet.has(day)) return;
       entriesByDay.set(day, [...(entriesByDay.get(day) ?? []), { card, kind }]);
     });
   });
@@ -37,23 +43,41 @@ export function CalendarView({ cards, onOpen }: { cards: Card[]; onOpen: (id: nu
     setDisplayMonth((current) => new Date(current.getFullYear(), current.getMonth() + delta, 1));
   }
 
+  function moveWeek(delta: number) {
+    setDisplayWeek((current) => addDays(current, delta * 7));
+  }
+
+  const visibleCells = mode === "month" ? dayCells : weekDays;
+
   return (
     <section className="panel">
       <div className="calendarToolbar">
-        <button onClick={() => moveMonth(-1)}>前月</button>
-        <h2>{displayMonth.getFullYear()}年 {displayMonth.getMonth() + 1}月</h2>
-        <button onClick={() => moveMonth(1)}>翌月</button>
-        <button onClick={() => setDisplayMonth(new Date(new Date().getFullYear(), new Date().getMonth(), 1))}>今月</button>
+        <button onClick={() => mode === "month" ? moveMonth(-1) : moveWeek(-1)}>{mode === "month" ? "前月" : "前週"}</button>
+        <h2>
+          {mode === "month"
+            ? `${displayMonth.getFullYear()}年 ${displayMonth.getMonth() + 1}月`
+            : `${weekDays[0]}〜${weekDays[6]}`}
+        </h2>
+        <button onClick={() => mode === "month" ? moveMonth(1) : moveWeek(1)}>{mode === "month" ? "翌月" : "翌週"}</button>
+        <div className="segmented">
+          <button className={mode === "month" ? "active" : ""} onClick={() => setMode("month")}>月</button>
+          <button className={mode === "week" ? "active" : ""} onClick={() => setMode("week")}>週</button>
+        </div>
+        <button onClick={() => {
+          const today = new Date();
+          setDisplayMonth(new Date(today.getFullYear(), today.getMonth(), 1));
+          setDisplayWeek(mondayOfWeek(today));
+        }}>今日</button>
       </div>
-      <div className="monthCalendar">
+      <div className={mode === "month" ? "monthCalendar" : "monthCalendar weekCalendar"}>
         {weekdays.map((weekday) => (
           <div className="weekday" key={weekday}>{weekday}</div>
         ))}
-        {dayCells.map((day, index) => (
+        {visibleCells.map((day, index) => (
           <div className={`dayCell ${day ? "" : "empty"} ${day === todayKey ? "today" : ""}`} key={day ?? `blank-${index}`}>
             {day && (
               <>
-                <div className="dayNumber">{Number(day.slice(-2))}</div>
+                <div className="dayNumber">{mode === "week" ? day.slice(5) : Number(day.slice(-2))}</div>
                 <div className="calendarItems">
                   {(entriesByDay.get(day) ?? []).slice(0, 4).map(({ card, kind }) => {
                     const late = kind === "納期" && day < todayKey && card.status !== "完了";
@@ -72,7 +96,7 @@ export function CalendarView({ cards, onOpen }: { cards: Card[]; onOpen: (id: nu
         ))}
       </div>
       <div className="calendarEmptyNote">
-        {dayCells.every((day) => !day || !entriesByDay.get(day)?.length) && "この月の予定・納期はありません"}
+        {visibleCells.every((day) => !day || !entriesByDay.get(day)?.length) && `この${mode === "month" ? "月" : "週"}の予定・納期はありません`}
       </div>
     </section>
   );

--- a/apps/machine-process-visibility/src/views/DashboardView.tsx
+++ b/apps/machine-process-visibility/src/views/DashboardView.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from "react";
+import { request } from "../api";
+import type { DashboardAssigneeSummary, DashboardPeriod, DashboardResponse } from "../types";
+import { localDateString, minutesLabel } from "../utils/date";
+
+export function DashboardView() {
+  const [period, setPeriod] = useState<DashboardPeriod>("month");
+  const [baseDate, setBaseDate] = useState(localDateString());
+  const [data, setData] = useState<DashboardResponse | null>(null);
+  const [selectedAssigneeId, setSelectedAssigneeId] = useState<number | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setError("");
+    request<DashboardResponse>(`/dashboard/workload?period=${period}&base_date=${baseDate}`)
+      .then((result) => {
+        setData(result);
+        setSelectedAssigneeId((current) => current ?? result.summaries[0]?.assignee.id ?? null);
+      })
+      .catch((err) => setError((err as Error).message));
+  }, [period, baseDate]);
+
+  const selected = useMemo<DashboardAssigneeSummary | null>(
+    () => data?.summaries.find((summary) => summary.assignee.id === selectedAssigneeId) ?? data?.summaries[0] ?? null,
+    [data, selectedAssigneeId],
+  );
+  const totals = useMemo(() => {
+    const summaries = data?.summaries ?? [];
+    return {
+      work_count: summaries.reduce((sum, item) => sum + item.work_count, 0),
+      completed_qty: summaries.reduce((sum, item) => sum + item.completed_qty, 0),
+      actual_minutes: summaries.reduce((sum, item) => sum + item.actual_minutes, 0),
+      estimated_minutes: summaries.reduce((sum, item) => sum + item.estimated_minutes, 0),
+    };
+  }, [data]);
+
+  return (
+    <section className="panel dashboard">
+      <div className="dashboardToolbar">
+        <div>
+          <h2>実績ダッシュボード</h2>
+          <p>{data ? `${data.label} (${data.start_date}〜${data.end_date})` : "集計中"}</p>
+        </div>
+        <div className="segmented">
+          <button className={period === "month" ? "active" : ""} onClick={() => setPeriod("month")}>月次</button>
+          <button className={period === "week" ? "active" : ""} onClick={() => setPeriod("week")}>週次</button>
+        </div>
+        <input type="date" value={baseDate} onChange={(event) => setBaseDate(event.target.value)} />
+      </div>
+      {error && <div className="error">{error}</div>}
+      {data && (
+        <>
+          <div className="summaryStrip">
+            <span>作業件数 <strong>{totals.work_count}</strong></span>
+            <span>加工数量 <strong>{totals.completed_qty}</strong></span>
+            <span>実績 <strong>{minutesLabel(totals.actual_minutes)}</strong></span>
+            <span>見積 <strong>{minutesLabel(totals.estimated_minutes)}</strong></span>
+            <span>差分 <strong>{minutesLabel(totals.estimated_minutes - totals.actual_minutes)}</strong></span>
+          </div>
+          <div className="assigneeMetrics">
+            {data.summaries.map((summary) => (
+              <button
+                key={summary.assignee.id}
+                className={summary.assignee.id === selectedAssigneeId ? "active metricCard" : "metricCard"}
+                onClick={() => setSelectedAssigneeId(summary.assignee.id)}
+              >
+                <span className="assigneeDot" style={{ backgroundColor: summary.assignee.color }} />
+                <strong>{summary.assignee.name}</strong>
+                <small>作業 {summary.work_count}件 / 数量 {summary.completed_qty}</small>
+                <span>実績 {minutesLabel(summary.actual_minutes)}</span>
+                <span>見積 {minutesLabel(summary.estimated_minutes)}</span>
+                <span className={summary.variance_minutes >= 0 ? "positive" : "negative"}>差分 {minutesLabel(summary.variance_minutes)}</span>
+              </button>
+            ))}
+          </div>
+          {selected && (
+            <div className="dashboardDetail">
+              <div className="detailHeader">
+                <h3>{selected.assignee.name} 詳細</h3>
+                <span>効率: {selected.efficiency_rate === null ? "-" : `${selected.efficiency_rate}%`}</span>
+              </div>
+              <div className="processBreakdown">
+                {selected.processes.length === 0 && <p>この期間の作業実績はありません。</p>}
+                {selected.processes.map((process) => (
+                  <div key={process.name}>
+                    <strong>{process.name}</strong>
+                    <span>{process.work_count}件</span>
+                    <span>実績 {minutesLabel(process.actual_minutes)}</span>
+                    <span>見積 {minutesLabel(process.estimated_minutes)}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="tableScroll">
+                <table>
+                  <thead>
+                    <tr><th>日付</th><th>時刻</th><th>工程</th><th>図番</th><th>分類</th><th>数量</th><th>実績</th><th>見積</th><th>差分</th></tr>
+                  </thead>
+                  <tbody>
+                    {selected.logs.map((log) => (
+                      <tr key={log.id}>
+                        <td>{log.work_date}</td>
+                        <td>{log.start_time ?? "-"}〜{log.end_time ?? "-"}</td>
+                        <td>{log.process_name}</td>
+                        <td>{log.drawing_no}</td>
+                        <td>{log.work_type}</td>
+                        <td>{log.completed_qty_delta}</td>
+                        <td>{minutesLabel(log.duration_minutes)}</td>
+                        <td>{minutesLabel(log.estimated_minutes)}</td>
+                        <td>{minutesLabel(log.estimated_minutes - log.duration_minutes)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Change machine PoC work-result entry from direct work-hours input to start/end time input, deriving actual duration in minutes on the backend.
- Add estimated minutes to work logs so actual vs estimated variance can be calculated.
- Add admin-only workload dashboard API and UI with month/week views, assignee comparison cards, and assignee detail drilldown.
- Hide the daily report navigation while leaving the existing reports API in place.
- Add Monday-start week support to the calendar alongside the existing month view.
- Seed PoC work logs with temporary start/end/estimate values inside the 08:00-22:00 working window.

## Validation

- `'/Users/matsumototakahiro/Documents/New project/.venv/bin/python' -m pytest backend/tests` in `apps/machine-process-visibility` -> 30 passed
- `'/Users/matsumototakahiro/Documents/New project/.venv/bin/python' -m compileall backend` in `apps/machine-process-visibility`
- `npm run build` in `apps/machine-process-visibility`
- GitHub Actions `Machine Process Visibility PoC`: success
- Local merge-tree against `main`: clean
- Local old-root app was also initialized and smoke-tested on `127.0.0.1:8000` / `127.0.0.1:5173`

## Notes

- DB initialization is assumed acceptable for this PoC, matching the current project direction.
- Contribution/monetary value is not hard-coded yet; this PR establishes the actual-vs-estimated data foundation needed for later monetary contribution metrics.